### PR TITLE
Add SQLAlchemy models and DB session setup

### DIFF
--- a/src/offsight/core/db.py
+++ b/src/offsight/core/db.py
@@ -1,0 +1,46 @@
+"""
+Database session and base setup for OffSight.
+
+Provides SQLAlchemy engine, session factory, declarative base, and FastAPI dependency.
+"""
+
+from typing import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import DeclarativeBase, sessionmaker
+
+from offsight.core.config import get_settings
+
+settings = get_settings()
+
+# Create SQLAlchemy engine
+engine = create_engine(
+    settings.database_url,
+    pool_pre_ping=True,  # Verify connections before using them
+    echo=False,  # Set to True for SQL query logging during development
+)
+
+# Create session factory
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+# Declarative base for models
+class Base(DeclarativeBase):
+    """Base class for all SQLAlchemy models."""
+
+    pass
+
+
+def get_db() -> Generator:
+    """
+    FastAPI dependency that provides a database session.
+
+    Yields:
+        Session: SQLAlchemy database session
+    """
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+

--- a/src/offsight/core/init_db.py
+++ b/src/offsight/core/init_db.py
@@ -1,0 +1,36 @@
+"""
+Database initialization helper.
+
+Creates all database tables based on the SQLAlchemy models.
+This is useful for local development to quickly set up the database schema.
+"""
+
+from offsight.core.db import Base, engine
+from offsight.models import (  # noqa: F401 - Import models to register them
+    Category,
+    RegulationChange,
+    RegulationDocument,
+    Source,
+    User,
+    ValidationRecord,
+)
+
+
+def init_db() -> None:
+    """
+    Create all database tables.
+
+    This function imports all models and creates the corresponding
+    database tables using SQLAlchemy's metadata.create_all().
+    """
+    # Import all models to ensure they are registered with Base
+    # The imports above ensure all models are loaded
+
+    # Create all tables
+    Base.metadata.create_all(bind=engine)
+    print("Database tables created successfully.")
+
+
+if __name__ == "__main__":
+    init_db()
+

--- a/src/offsight/models/__init__.py
+++ b/src/offsight/models/__init__.py
@@ -1,2 +1,17 @@
 """Database models for OffSight."""
 
+from offsight.models.category import Category
+from offsight.models.regulation_change import RegulationChange
+from offsight.models.regulation_document import RegulationDocument
+from offsight.models.source import Source
+from offsight.models.user import User
+from offsight.models.validation_record import ValidationRecord
+
+__all__ = [
+    "Category",
+    "RegulationChange",
+    "RegulationDocument",
+    "Source",
+    "User",
+    "ValidationRecord",
+]

--- a/src/offsight/models/category.py
+++ b/src/offsight/models/category.py
@@ -1,0 +1,33 @@
+"""
+Category model for regulatory change classification.
+"""
+
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from offsight.core.db import Base
+
+
+class Category(Base):
+    """
+    Category model for classifying regulatory changes.
+
+    Represents predefined categories like "Grid Connection", "Safety and Health",
+    "Environment", "Certification/Documentation", and "Other".
+    """
+
+    __tablename__ = "categories"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
+    description: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    color: Mapped[str | None] = mapped_column(String(20), nullable=True)
+
+    # Relationships
+    regulation_changes: Mapped[list["RegulationChange"]] = relationship(
+        "RegulationChange", back_populates="category"
+    )
+
+    def __repr__(self) -> str:
+        return f"<Category(id={self.id}, name='{self.name}')>"
+

--- a/src/offsight/models/regulation_change.py
+++ b/src/offsight/models/regulation_change.py
@@ -1,0 +1,60 @@
+"""
+RegulationChange model for detected changes between document versions.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from offsight.core.db import Base
+
+
+class RegulationChange(Base):
+    """
+    RegulationChange model for detected changes between document versions.
+
+    Represents a detected change between two versions of a RegulationDocument,
+    containing the computed difference, AI-generated summary, and classification.
+    """
+
+    __tablename__ = "regulation_changes"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    previous_document_id: Mapped[int] = mapped_column(
+        ForeignKey("regulation_documents.id"), nullable=False
+    )
+    new_document_id: Mapped[int] = mapped_column(
+        ForeignKey("regulation_documents.id"), nullable=False
+    )
+    diff_content: Mapped[str] = mapped_column(Text, nullable=False)
+    ai_summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    category_id: Mapped[int | None] = mapped_column(
+        ForeignKey("categories.id"), nullable=True
+    )
+    detected_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(50), default="pending", nullable=False
+    )
+
+    # Relationships
+    previous_document: Mapped["RegulationDocument"] = relationship(
+        "RegulationDocument",
+        foreign_keys=[previous_document_id],
+        back_populates="previous_changes",
+    )
+    new_document: Mapped["RegulationDocument"] = relationship(
+        "RegulationDocument",
+        foreign_keys=[new_document_id],
+        back_populates="new_changes",
+    )
+    category: Mapped["Category | None"] = relationship(
+        "Category", back_populates="regulation_changes"
+    )
+    validation_records: Mapped[list["ValidationRecord"]] = relationship(
+        "ValidationRecord", back_populates="regulation_change"
+    )
+
+    def __repr__(self) -> str:
+        return f"<RegulationChange(id={self.id}, status='{self.status}')>"
+

--- a/src/offsight/models/regulation_document.py
+++ b/src/offsight/models/regulation_document.py
@@ -1,0 +1,47 @@
+"""
+RegulationDocument model for versioned document snapshots.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from offsight.core.db import Base
+
+
+class RegulationDocument(Base):
+    """
+    RegulationDocument model for versioned document snapshots.
+
+    Represents a snapshot of a regulatory document retrieved from a Source
+    at a specific point in time.
+    """
+
+    __tablename__ = "regulation_documents"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    source_id: Mapped[int] = mapped_column(ForeignKey("sources.id"), nullable=False)
+    version: Mapped[str] = mapped_column(String(100), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    content_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    retrieved_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    url: Mapped[str] = mapped_column(String(500), nullable=False)
+    document_metadata: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Relationships
+    source: Mapped["Source"] = relationship("Source", back_populates="regulation_documents")
+    previous_changes: Mapped[list["RegulationChange"]] = relationship(
+        "RegulationChange",
+        foreign_keys="RegulationChange.previous_document_id",
+        back_populates="previous_document",
+    )
+    new_changes: Mapped[list["RegulationChange"]] = relationship(
+        "RegulationChange",
+        foreign_keys="RegulationChange.new_document_id",
+        back_populates="new_document",
+    )
+
+    def __repr__(self) -> str:
+        return f"<RegulationDocument(id={self.id}, source_id={self.source_id}, version='{self.version}')>"
+

--- a/src/offsight/models/source.py
+++ b/src/offsight/models/source.py
@@ -1,0 +1,42 @@
+"""
+Source model for regulatory sources.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from offsight.core.db import Base
+
+
+class Source(Base):
+    """
+    Source model for configured regulatory sources.
+
+    Represents a regulatory source that OffSight monitors for changes,
+    such as a URL to a regulation page or an API endpoint.
+    """
+
+    __tablename__ = "sources"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    url: Mapped[str] = mapped_column(String(500), nullable=False)
+    description: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+    # Relationships
+    regulation_documents: Mapped[list["RegulationDocument"]] = relationship(
+        "RegulationDocument", back_populates="source"
+    )
+
+    def __repr__(self) -> str:
+        return f"<Source(id={self.id}, name='{self.name}', enabled={self.enabled})>"
+

--- a/src/offsight/models/user.py
+++ b/src/offsight/models/user.py
@@ -1,0 +1,40 @@
+"""
+User model for system users.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from offsight.core.db import Base
+
+
+class User(Base):
+    """
+    User model for system users.
+
+    Represents a person who interacts with OffSight to view, validate,
+    or manage regulatory changes.
+    """
+
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    username: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
+    email: Mapped[str] = mapped_column(String(200), unique=True, nullable=False)
+    full_name: Mapped[str] = mapped_column(String(200), nullable=False)
+    role: Mapped[str] = mapped_column(String(50), default="viewer", nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, nullable=False
+    )
+    last_login_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+    # Relationships
+    validation_records: Mapped[list["ValidationRecord"]] = relationship(
+        "ValidationRecord", back_populates="user"
+    )
+
+    def __repr__(self) -> str:
+        return f"<User(id={self.id}, username='{self.username}', role='{self.role}')>"
+

--- a/src/offsight/models/validation_record.py
+++ b/src/offsight/models/validation_record.py
@@ -1,0 +1,45 @@
+"""
+ValidationRecord model for user validations of AI-generated changes.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from offsight.core.db import Base
+
+
+class ValidationRecord(Base):
+    """
+    ValidationRecord model for user validations.
+
+    Represents a user's validation or correction of an AI-generated summary
+    and category for a RegulationChange.
+    """
+
+    __tablename__ = "validation_records"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    change_id: Mapped[int] = mapped_column(
+        ForeignKey("regulation_changes.id"), nullable=False
+    )
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    validated_summary: Mapped[str] = mapped_column(Text, nullable=False)
+    validated_category_id: Mapped[int | None] = mapped_column(
+        ForeignKey("categories.id"), nullable=True
+    )
+    validation_status: Mapped[str] = mapped_column(String(50), nullable=False)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    validated_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+
+    # Relationships
+    regulation_change: Mapped["RegulationChange"] = relationship(
+        "RegulationChange", back_populates="validation_records"
+    )
+    user: Mapped["User"] = relationship("User", back_populates="validation_records")
+    validated_category: Mapped["Category | None"] = relationship("Category")
+
+    def __repr__(self) -> str:
+        return f"<ValidationRecord(id={self.id}, change_id={self.change_id}, status='{self.validation_status}')>"
+


### PR DESCRIPTION
### Summary
Add SQLAlchemy models for core entities and configure PostgreSQL DB session layer.

### Changes
- Added src/offsight/core/db.py with engine, Base, SessionLocal, and get_db() dependency
- Implemented SQLAlchemy models for Source, RegulationDocument, RegulationChange, Category, User, ValidationRecord
- Added src/offsight/core/init_db.py helper for creating tables during development

### Closes
Closes #10
Closes #19
Closes #20
Closes #21

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce SQLAlchemy engine/session and define core models with relationships, plus an init helper to create tables.
> 
> - **Data layer**:
>   - **DB core**: Add `engine`, `SessionLocal`, `Base`, and FastAPI dependency `get_db()` in `src/offsight/core/db.py`.
>   - **Models**: Implement `Source`, `RegulationDocument`, `RegulationChange`, `Category`, `User`, `ValidationRecord` with mapped columns and relationships:
>     - `Source` ↔ `RegulationDocument` (`source`/`regulation_documents`).
>     - `RegulationDocument` ↔ `RegulationChange` (`previous_changes`/`new_changes`).
>     - `Category` ↔ `RegulationChange` (`category`/`regulation_changes`).
>     - `User` ↔ `ValidationRecord` (`validation_records`).
>     - `ValidationRecord` links to `RegulationChange`, `User`, and optional `Category`.
>   - **Initialization**: Add `src/offsight/core/init_db.py` to create all tables via `Base.metadata.create_all()`; expose models in `src/offsight/models/__init__.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb3e8a0db0d0ceb24774307a0a29b8b22a43a924. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->