### PR TITLE
Add change detection service for versioned regulatory documents

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,4 +1,22 @@
 # Architecture Decision Records
 
-_This document will record key architectural decisions for OffSight._
+_This document will record key architectural decisions for OffSight along with the reasoning behind it._
+
+## ADR-011 – Handling Protected/Blocked Sources
+
+- Some official sites (e.g., GOV.UK/HSE) may use bot protection or return non-standard HTTP codes when scraped.
+- OffSight logs HTTP/network errors and skips the offending source instead of crashing the pipeline.
+- For development and testing, we prefer scrape-friendly public guidance pages or locally mirrored text.
+- Rationale: respect site policies, maintain pipeline resilience, and keep the focus on architecture and downstream processing rather than evading protections.
+
+## ADR-012 – Change Detection Approach
+
+- Change detection is implemented by comparing consecutive versions of RegulationDocument per source.
+- RegulationChange rows store:
+  - References to old and new documents (previous_document_id, new_document_id)
+  - A text-based diff representation (using Python's difflib.unified_diff)
+  - Detection timestamp and status ("pending" initially, before AI processing)
+- Duplicate change records are prevented by checking for existing RegulationChange entries linking the same document pair.
+- AI summarisation will use RegulationChange as input instead of re-computing diffs, keeping concerns separated.
+- Rationale: store diffs once at detection time, enable efficient AI processing later, and maintain clear separation between change detection and AI analysis.
 

--- a/src/offsight/core/run_change_detection_example.py
+++ b/src/offsight/core/run_change_detection_example.py
@@ -1,0 +1,72 @@
+"""
+Example script to run the change detection service.
+
+This script demonstrates how to use the ChangeDetectionService to detect
+changes between document versions and create RegulationChange entries.
+"""
+
+from offsight.core.db import SessionLocal
+from offsight.models.source import Source
+from offsight.services.change_detection_service import ChangeDetectionService
+
+
+def run_change_detection_example() -> None:
+    """
+    Run an example change detection operation.
+
+    Loads a Source and runs the change detection service to find
+    changes between consecutive document versions.
+    """
+    db = SessionLocal()
+    try:
+        # Load the first source
+        source = db.query(Source).first()
+
+        if not source:
+            print("No sources found. Please run the scraper first to create sources and documents.")
+            return
+
+        print(f"Detecting changes for source: {source.name} (ID: {source.id})")
+
+        # Instantiate change detection service
+        change_service = ChangeDetectionService()
+
+        # Get ordered documents to check how many we have
+        documents = change_service.get_ordered_documents(source.id, db)
+        print(f"Found {len(documents)} document version(s) for this source.")
+
+        if len(documents) < 2:
+            print("No changes detected. Need at least 2 document versions to detect changes.")
+            return
+
+        # Detect changes
+        created_changes = change_service.detect_changes_for_source(source.id, db)
+
+        # Print results
+        print(f"\n✓ Created {len(created_changes)} new RegulationChange row(s).")
+
+        if created_changes:
+            print("\nChange details:")
+            for change in created_changes:
+                prev_doc = change.previous_document
+                new_doc = change.new_document
+                print(f"  - Change ID: {change.id}")
+                print(f"    Previous: Document ID {prev_doc.id} (version {prev_doc.version})")
+                print(f"    New: Document ID {new_doc.id} (version {new_doc.version})")
+                print(f"    Detected at: {change.detected_at}")
+                print(f"    Status: {change.status}")
+                print(f"    Diff length: {len(change.diff_content)} characters")
+        else:
+            print("\nNo new changes detected. All consecutive document pairs already have change records.")
+
+    except Exception as e:
+        print(f"\n✗ Error during change detection: {e}")
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    run_change_detection_example()
+

--- a/src/offsight/core/run_scraper_example.py
+++ b/src/offsight/core/run_scraper_example.py
@@ -5,6 +5,8 @@ This script demonstrates how to use the ScraperService to fetch and store
 regulatory documents. It can be run manually during development.
 """
 
+from httpx import HTTPStatusError, RequestError
+
 from offsight.core.db import SessionLocal
 from offsight.models.source import Source
 from offsight.services.scraper_service import ScraperService
@@ -26,15 +28,30 @@ def run_example_scrape() -> None:
             # Create a default source if none exists
             print("No sources found. Creating a default source...")
             source = Source(
-                name="Offshore Wind Safety Regulations",
-                url="https://www.legislation.gov.uk/ukpga/2023/52",
-                description="Example UK legislation source for testing",
+                name="OREI impact on shipping – GOV.UK",
+                url="https://www.gov.uk/guidance/offshore-renewable-energy-installations-impact-on-shipping",
+                description="GOV.UK guidance page used as a scrape-friendly default source",
                 enabled=True,
             )
             db.add(source)
             db.commit()
             db.refresh(source)
             print(f"Created source: {source.name} (ID: {source.id})")
+        else:
+            # If the existing first source is the old default, update it to the new GOV.UK source
+            old_default_url = "https://www.legislation.gov.uk/ukpga/2023/52"
+            if source.url == old_default_url:
+                print("Updating existing default source to the new GOV.UK guidance page...")
+                source.name = "OREI impact on shipping – GOV.UK"
+                source.url = (
+                    "https://www.gov.uk/guidance/offshore-renewable-energy-installations-impact-on-shipping"
+                )
+                source.description = (
+                    "GOV.UK guidance page used as a scrape-friendly default source"
+                )
+                db.commit()
+                db.refresh(source)
+                print(f"Updated source: {source.name} (ID: {source.id})")
 
         print(f"\nScraping source: {source.name} ({source.url})")
 
@@ -42,7 +59,20 @@ def run_example_scrape() -> None:
         scraper = ScraperService()
 
         # Fetch and store if changed
-        new_doc = scraper.fetch_and_store_if_changed(source.id, db)
+        try:
+            new_doc = scraper.fetch_and_store_if_changed(source.id, db)
+        except (HTTPStatusError, RequestError) as exc:
+            print(
+                "\n[WARN] Skipping source due to HTTP error / protection. "
+                f"Reason: {exc}"
+            )
+            new_doc = None
+        except Exception as exc:
+            print(
+                "\n[WARN] Skipping source due to unexpected error. "
+                f"Reason: {exc}"
+            )
+            new_doc = None
 
         if new_doc:
             print(f"\n✓ New document version stored!")

--- a/src/offsight/services/change_detection_service.py
+++ b/src/offsight/services/change_detection_service.py
@@ -1,0 +1,140 @@
+"""
+Change detection service for comparing document versions.
+
+Handles detection of changes between consecutive RegulationDocument versions
+and creates RegulationChange entries with textual diffs.
+"""
+
+import difflib
+from datetime import datetime
+
+from sqlalchemy import and_
+from sqlalchemy.orm import Session
+
+from offsight.models.regulation_change import RegulationChange
+from offsight.models.regulation_document import RegulationDocument
+
+
+class ChangeDetectionService:
+    """Service for detecting changes between document versions."""
+
+    def get_ordered_documents(
+        self, source_id: int, db: Session
+    ) -> list[RegulationDocument]:
+        """
+        Return all RegulationDocument entries for the given source,
+        ordered by version (or by retrieved_at if version is not numeric).
+
+        Args:
+            source_id: The ID of the Source to get documents for
+            db: SQLAlchemy database session
+
+        Returns:
+            List of RegulationDocument entries ordered by version/retrieved_at
+        """
+        documents = (
+            db.query(RegulationDocument)
+            .filter(RegulationDocument.source_id == source_id)
+            .all()
+        )
+
+        # Try to sort by numeric version, fall back to retrieved_at
+        def sort_key(doc: RegulationDocument) -> tuple[int, datetime]:
+            try:
+                version_num = int(doc.version)
+            except ValueError:
+                # If version is not numeric, use a large number and sort by retrieved_at
+                version_num = 999999
+            return (version_num, doc.retrieved_at)
+
+        return sorted(documents, key=sort_key)
+
+    def detect_changes_for_source(
+        self, source_id: int, db: Session
+    ) -> list[RegulationChange]:
+        """
+        For the given source, detect changes between consecutive document versions.
+
+        - Load ordered documents.
+        - For each pair of consecutive documents (previous, current):
+          - Check if a RegulationChange already exists linking these two documents.
+          - If not, compute a textual diff between previous.content and current.content
+            (using difflib.unified_diff line-by-line).
+          - Create a new RegulationChange with:
+            - previous_document_id
+            - new_document_id
+            - diff_content (string)
+            - detected_at (current UTC timestamp)
+            - status = "pending"
+
+        Args:
+            source_id: The ID of the Source to detect changes for
+            db: SQLAlchemy database session
+
+        Returns:
+            List of RegulationChange rows created in this run
+        """
+        documents = self.get_ordered_documents(source_id, db)
+
+        if len(documents) < 2:
+            # Need at least 2 documents to detect changes
+            return []
+
+        created_changes: list[RegulationChange] = []
+
+        # Iterate through consecutive pairs
+        for i in range(len(documents) - 1):
+            previous_doc = documents[i]
+            current_doc = documents[i + 1]
+
+            # Check if a RegulationChange already exists for this pair
+            existing_change = (
+                db.query(RegulationChange)
+                .filter(
+                    and_(
+                        RegulationChange.previous_document_id == previous_doc.id,
+                        RegulationChange.new_document_id == current_doc.id,
+                    )
+                )
+                .first()
+            )
+
+            if existing_change:
+                # Skip if change already detected
+                continue
+
+            # Compute textual diff using difflib
+            previous_lines = previous_doc.content.splitlines(keepends=True)
+            current_lines = current_doc.content.splitlines(keepends=True)
+
+            diff_lines = difflib.unified_diff(
+                previous_lines,
+                current_lines,
+                fromfile=f"version_{previous_doc.version}",
+                tofile=f"version_{current_doc.version}",
+                lineterm="",
+            )
+
+            diff_content = "".join(diff_lines)
+
+            # Create new RegulationChange
+            new_change = RegulationChange(
+                previous_document_id=previous_doc.id,
+                new_document_id=current_doc.id,
+                diff_content=diff_content,
+                detected_at=datetime.utcnow(),
+                status="pending",
+            )
+
+            db.add(new_change)
+            created_changes.append(new_change)
+
+        # Commit all changes at once
+        if created_changes:
+            db.commit()
+            # Refresh all created changes to get their IDs
+            for change in created_changes:
+                db.refresh(change)
+
+        return created_changes
+

--- a/src/offsight/services/scraper_service.py
+++ b/src/offsight/services/scraper_service.py
@@ -10,6 +10,7 @@ from datetime import datetime
 
 from bs4 import BeautifulSoup
 import httpx
+from httpx import HTTPStatusError, RequestError
 from sqlalchemy import desc
 from sqlalchemy.orm import Session
 
@@ -29,7 +30,7 @@ class ScraperService:
         """
         self.timeout = timeout
 
-    def fetch_raw_content(self, source: Source) -> str:
+    def fetch_raw_content(self, source: Source) -> str | None:
         """
         Fetch and extract text content from a source URL.
 
@@ -37,16 +38,26 @@ class ScraperService:
             source: The Source entity to fetch content from
 
         Returns:
-            Extracted text content as a string
+            Extracted text content as a string, or None if the fetch failed.
 
-        Raises:
-            httpx.HTTPError: If the HTTP request fails
+        Notes:
+            HTTP/network errors are caught and logged; returns None on failure.
         """
         # Fetch the HTML content
-        with httpx.Client(timeout=self.timeout) as client:
-            response = client.get(source.url)
-            response.raise_for_status()
-            html_content = response.text
+        try:
+            with httpx.Client(timeout=self.timeout) as client:
+                response = client.get(source.url)
+                response.raise_for_status()
+                html_content = response.text
+        except HTTPStatusError as exc:
+            status = exc.response.status_code if exc.response else "unknown"
+            print(
+                f"[ERROR] HTTP status error while fetching {source.url}: {status} ({exc})"
+            )
+            return None
+        except RequestError as exc:
+            print(f"[ERROR] Network error while fetching {source.url}: {exc}")
+            return None
 
         # Parse HTML with BeautifulSoup
         soup = BeautifulSoup(html_content, "html.parser")
@@ -77,11 +88,13 @@ class ScraperService:
             db: SQLAlchemy database session
 
         Returns:
-            New RegulationDocument if content changed, None otherwise
+            New RegulationDocument if content changed, None if unchanged or fetch failed.
 
         Raises:
             ValueError: If source not found
-            httpx.HTTPError: If the HTTP request fails
+
+        Notes:
+            HTTP/network errors are handled and logged; returns None on failure.
         """
         # Load the source
         source = db.query(Source).filter(Source.id == source_id).first()
@@ -93,6 +106,8 @@ class ScraperService:
 
         # Fetch raw content
         content = self.fetch_raw_content(source)
+        if content is None:
+            return None
 
         # Compute content hash (SHA256)
         content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()


### PR DESCRIPTION
### Changes
- Added ChangeDetectionService to compute diffs between RegulationDocument versions
- Added run_change_detection_example.py
- Updated decisions.md with ADR-012
- Ensures duplicate change records are not created

### Closes
Closes #12
Closes #5 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds change detection with stored diffs and example runner, improves scraper resilience to HTTP/protection issues, and documents ADRs for scraping and change detection.
> 
> - **Core/Services**:
>   - **`ChangeDetectionService`**:
>     - Detects changes between consecutive `RegulationDocument` versions and stores unified diffs in `RegulationChange`.
>     - Prevents duplicate change rows and commits in batch.
>     - Orders documents by numeric `version` (fallback to `retrieved_at`).
>   - **`ScraperService`**:
>     - Catches `HTTPStatusError`/`RequestError`, logs, and returns `None` on fetch failure.
>     - Updates return types and notes; unchanged content short-circuits without new version.
> - **CLI/Examples**:
>   - **`src/offsight/core/run_change_detection_example.py`**: Runs detection for the first `Source`, reports created `RegulationChange` entries.
>   - **`src/offsight/core/run_scraper_example.py`**: Uses GOV.UK guidance as default source, updates old default if present, and skips on HTTP/protection errors.
> - **Docs**:
>   - **`docs/decisions.md`**: Adds ADR-011 (handling protected/blocked sources) and ADR-012 (change detection approach).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bd9e0a1997574f6d3a44e98fa0331522e142a44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->