### PR TITLE
Add server-rendered UI for reviewing and validating changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,7 @@ sqlalchemy
 psycopg2-binary
 httpx
 beautifulsoup4
+jinja2
+python-multipart
 pytest
 

--- a/src/offsight/main.py
+++ b/src/offsight/main.py
@@ -13,6 +13,7 @@ Or from the project root:
 from fastapi import FastAPI
 
 from offsight.api import changes, sources, validation
+from offsight.ui.routes import router as ui_router
 
 app = FastAPI(
     title="OffSight™ - Regulatory Intelligence",
@@ -24,6 +25,9 @@ app = FastAPI(
 app.include_router(sources.router, prefix="/sources", tags=["sources"])
 app.include_router(changes.router, prefix="/changes", tags=["changes"])
 app.include_router(validation.router, tags=["validation"])
+
+# Include UI router
+app.include_router(ui_router, prefix="/ui", tags=["ui"])
 
 
 @app.get("/health")

--- a/src/offsight/services/validation_service.py
+++ b/src/offsight/services/validation_service.py
@@ -1,0 +1,197 @@
+"""
+Shared validation service logic for both API and UI endpoints.
+
+Extracts common validation logic to avoid code duplication.
+"""
+
+from datetime import UTC, datetime
+
+from sqlalchemy.orm import Session
+
+from offsight.models.category import Category
+from offsight.models.regulation_change import RegulationChange
+from offsight.models.user import User
+from offsight.models.validation_record import ValidationRecord
+
+
+def get_or_create_demo_user(db: Session) -> User:
+    """
+    Get or create a demo user for validation.
+
+    Args:
+        db: Database session
+
+    Returns:
+        User instance with username="demo"
+    """
+    demo_user = db.query(User).filter(User.username == "demo").first()
+
+    if not demo_user:
+        demo_user = User(
+            username="demo",
+            email="demo@offsight.local",
+            full_name="Demo Reviewer",
+            role="reviewer",
+            created_at=datetime.now(UTC),
+        )
+        db.add(demo_user)
+        db.flush()
+
+    return demo_user
+
+
+def normalize_category_name(category_name: str) -> str:
+    """
+    Normalize a category name to match database format.
+
+    Args:
+        category_name: Category name string
+
+    Returns:
+        Normalized name
+    """
+    category_mappings = {
+        "grid_connection": "Grid Connection",
+        "grid connection": "Grid Connection",
+        "grid": "Grid Connection",
+        "safety_and_health": "Safety and Health",
+        "safety and health": "Safety and Health",
+        "safety": "Safety and Health",
+        "health": "Safety and Health",
+        "environment": "Environment",
+        "env": "Environment",
+        "certification_documentation": "Certification/Documentation",
+        "certification/documentation": "Certification/Documentation",
+        "certification": "Certification/Documentation",
+        "documentation": "Certification/Documentation",
+        "other": "Other",
+    }
+
+    normalized = category_name.lower().strip().replace(" ", "_")
+    return category_mappings.get(normalized, category_name.title())
+
+
+def get_or_create_category(category_name: str, db: Session) -> Category:
+    """
+    Get or create a Category by name.
+
+    Args:
+        category_name: Category name (will be normalized)
+        db: Database session
+
+    Returns:
+        Category instance
+    """
+    normalized_name = normalize_category_name(category_name)
+
+    category = db.query(Category).filter(Category.name == normalized_name).first()
+
+    if not category:
+        category = Category(
+            name=normalized_name,
+            description=f"Regulatory changes related to {normalized_name.lower()}",
+        )
+        db.add(category)
+        db.flush()
+
+    return category
+
+
+def process_validation(
+    change: RegulationChange,
+    decision: str,
+    user_id: int | None,
+    final_summary: str | None,
+    final_category: str | None,
+    notes: str | None,
+    db: Session,
+) -> tuple[ValidationRecord, str, str | None]:
+    """
+    Process a validation decision and create ValidationRecord.
+
+    Args:
+        change: The RegulationChange to validate
+        decision: One of "approved", "corrected", "rejected"
+        user_id: Optional user ID (will use demo user if not provided)
+        final_summary: Optional final summary text
+        final_category: Optional final category name
+        notes: Optional validation notes
+        db: Database session
+
+    Returns:
+        Tuple of (ValidationRecord, final_summary, final_category_name)
+
+    Raises:
+        ValueError: If validation data is invalid
+    """
+    # Determine user
+    if user_id:
+        user = db.query(User).filter(User.id == user_id).first()
+        if not user:
+            user = get_or_create_demo_user(db)
+    else:
+        user = get_or_create_demo_user(db)
+
+    # Determine final summary and category based on decision
+    if decision == "approved":
+        final_summary = change.ai_summary
+        final_category_name = change.category.name if change.category else None
+        final_category_id = change.category_id
+
+    elif decision == "corrected":
+        if not final_summary:
+            raise ValueError("final_summary is required when decision is 'corrected'.")
+        if not final_category:
+            raise ValueError("final_category is required when decision is 'corrected'.")
+
+        category = get_or_create_category(final_category, db)
+        final_category_name = category.name
+        final_category_id = category.id
+
+    elif decision == "rejected":
+        if not final_summary:
+            final_summary = "Rejected"
+        if final_category:
+            category = get_or_create_category(final_category, db)
+            final_category_name = category.name
+            final_category_id = category.id
+        else:
+            category = get_or_create_category("other", db)
+            final_category_name = category.name
+            final_category_id = category.id
+
+    else:
+        raise ValueError(f"Invalid decision: {decision}")
+
+    # Ensure final_summary is not None
+    if final_summary is None:
+        final_summary = "Rejected" if decision == "rejected" else ""
+
+    # Create ValidationRecord
+    validation_record = ValidationRecord(
+        change_id=change.id,
+        user_id=user.id,
+        validated_summary=final_summary,
+        validated_category_id=final_category_id,
+        validation_status=decision,
+        notes=notes,
+        validated_at=datetime.now(UTC),
+    )
+
+    db.add(validation_record)
+
+    # Update RegulationChange status
+    if decision == "approved":
+        change.status = "validated"
+    elif decision == "corrected":
+        change.status = "corrected"
+    elif decision == "rejected":
+        change.status = "rejected"
+
+    # Optionally update change with final values
+    if decision in ["corrected", "rejected"]:
+        change.ai_summary = final_summary
+        change.category_id = final_category_id
+
+    return validation_record, final_summary, final_category_name
+

--- a/src/offsight/ui/routes.py
+++ b/src/offsight/ui/routes.py
@@ -1,0 +1,284 @@
+"""
+UI router for server-rendered HTML pages.
+
+Provides web interface for viewing and validating regulatory changes.
+"""
+
+from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+from offsight.core.db import get_db
+from offsight.models.category import Category
+from offsight.models.regulation_change import RegulationChange
+from offsight.models.regulation_document import RegulationDocument
+from offsight.models.source import Source
+from offsight.models.validation_record import ValidationRecord
+from offsight.services.validation_service import process_validation
+
+router = APIRouter()
+
+# Setup Jinja2 templates - use absolute path from project root
+import os
+from pathlib import Path
+
+# Get the project root (assuming this file is in src/offsight/ui/)
+project_root = Path(__file__).parent.parent.parent.parent
+templates_dir = project_root / "src" / "offsight" / "ui" / "templates"
+templates = Jinja2Templates(directory=str(templates_dir))
+
+
+@router.get("/changes", response_class=HTMLResponse, tags=["ui"])
+def list_changes_ui(
+    request: Request,
+    status_filter: str | None = None,
+    source_id: int | None = None,
+    db: Session = Depends(get_db),
+):
+    """
+    Render the changes list page with optional filters.
+
+    Args:
+        request: FastAPI request object
+        status_filter: Optional status filter
+        source_id: Optional source ID filter
+        db: Database session
+
+    Returns:
+        Rendered HTML page
+    """
+    # Build query similar to API endpoint
+    query = (
+        db.query(
+            RegulationChange,
+            Source.name.label("source_name"),
+            Category.name.label("category_name"),
+        )
+        .join(
+            RegulationDocument,
+            RegulationChange.previous_document_id == RegulationDocument.id,
+        )
+        .join(Source, RegulationDocument.source_id == Source.id)
+        .outerjoin(Category, RegulationChange.category_id == Category.id)
+    )
+
+    # Apply filters
+    if status_filter:
+        query = query.filter(RegulationChange.status == status_filter)
+    if source_id:
+        query = query.filter(Source.id == source_id)
+
+    # Apply ordering
+    query = query.order_by(RegulationChange.detected_at.desc())
+
+    # Get results
+    results = query.limit(100).all()
+
+    # Build change list
+    changes = []
+    for change, source_name, category_name in results:
+        changes.append(
+            {
+                "id": change.id,
+                "detected_at": change.detected_at,
+                "source_name": source_name or "Unknown",
+                "status": change.status,
+                "category_name": category_name,
+                "ai_summary": change.ai_summary,
+            }
+        )
+
+    return templates.TemplateResponse(
+        "changes_list.html",
+        {
+            "request": request,
+            "changes": changes,
+            "status": status_filter,
+            "source_id": source_id,
+        },
+    )
+
+
+@router.get("/changes/{change_id}", response_class=HTMLResponse, tags=["ui"])
+def change_detail_ui(
+    request: Request,
+    change_id: int,
+    success: str | None = None,
+    db: Session = Depends(get_db),
+):
+    """
+    Render the change detail page with validation form.
+
+    Args:
+        request: FastAPI request object
+        change_id: The ID of the change to display
+        db: Database session
+
+    Returns:
+        Rendered HTML page
+
+    Raises:
+        HTTPException: 404 if change not found
+    """
+    # Load change with joins
+    change = (
+        db.query(RegulationChange)
+        .outerjoin(Category, RegulationChange.category_id == Category.id)
+        .filter(RegulationChange.id == change_id)
+        .first()
+    )
+
+    if not change:
+        raise HTTPException(status_code=404, detail=f"Change with id {change_id} not found")
+
+    # Get source name
+    prev_doc = (
+        db.query(RegulationDocument)
+        .filter(RegulationDocument.id == change.previous_document_id)
+        .first()
+    )
+
+    source_name = "Unknown"
+    if prev_doc:
+        source = db.query(Source).filter(Source.id == prev_doc.source_id).first()
+        if source:
+            source_name = source.name
+
+    # Get document versions
+    new_doc = (
+        db.query(RegulationDocument)
+        .filter(RegulationDocument.id == change.new_document_id)
+        .first()
+    )
+
+    category_name = change.category.name if change.category else None
+
+    # Get validation history
+    validations = (
+        db.query(ValidationRecord)
+        .filter(ValidationRecord.change_id == change_id)
+        .order_by(ValidationRecord.validated_at.desc())
+        .all()
+    )
+
+    validation_list = [
+        {
+            "decision": val.validation_status,
+            "validated_at": val.validated_at,
+            "notes": val.notes,
+        }
+        for val in validations
+    ]
+
+    return templates.TemplateResponse(
+        "change_detail.html",
+        {
+            "request": request,
+            "change": change,
+            "source_name": source_name,
+            "previous_version": prev_doc.version if prev_doc else None,
+            "new_version": new_doc.version if new_doc else None,
+            "category_name": category_name,
+            "validations": validation_list,
+            "success_message": success,
+        },
+    )
+
+
+@router.post("/changes/{change_id}/validate", tags=["ui"])
+def validate_change_ui(
+    request: Request,
+    change_id: int,
+    decision: str = Form(...),
+    final_summary: str | None = Form(None),
+    final_category: str | None = Form(None),
+    notes: str | None = Form(None),
+    db: Session = Depends(get_db),
+):
+    """
+    Handle validation form submission.
+
+    Args:
+        request: FastAPI request object
+        change_id: The ID of the change to validate
+        decision: Validation decision (approved/corrected/rejected)
+        final_summary: Optional final summary
+        final_category: Optional final category
+        notes: Optional notes
+        db: Database session
+
+    Returns:
+        Redirect to change detail page
+
+    Raises:
+        HTTPException: 404 if change not found, 400 if validation data invalid
+    """
+    # Load change
+    change = db.query(RegulationChange).filter(RegulationChange.id == change_id).first()
+
+    if not change:
+        raise HTTPException(status_code=404, detail=f"Change with id {change_id} not found")
+
+    # Check if diff_content is available
+    if not change.diff_content or len(change.diff_content.strip()) == 0:
+        return templates.TemplateResponse(
+            "change_detail.html",
+            {
+                "request": request,
+                "change": change,
+                "source_name": "Unknown",
+                "error_message": "No diff_content available for this change.",
+            },
+            status_code=400,
+        )
+
+    # Process validation
+    try:
+        validation_record, final_summary_result, final_category_name = process_validation(
+            change=change,
+            decision=decision,
+            user_id=None,  # Use demo user
+            final_summary=final_summary if final_summary else None,
+            final_category=final_category if final_category else None,
+            notes=notes if notes else None,
+            db=db,
+        )
+
+        db.commit()
+
+        # Redirect with success message
+        return RedirectResponse(
+            url=f"/ui/changes/{change_id}?success=Validation submitted successfully",
+            status_code=status.HTTP_303_SEE_OTHER,
+        )
+
+    except ValueError as e:
+        # Validation error - show error message
+        prev_doc = (
+            db.query(RegulationDocument)
+            .filter(RegulationDocument.id == change.previous_document_id)
+            .first()
+        )
+        source_name = "Unknown"
+        if prev_doc:
+            source = db.query(Source).filter(Source.id == prev_doc.source_id).first()
+            if source:
+                source_name = source.name
+
+        category_name = change.category.name if change.category else None
+
+        return templates.TemplateResponse(
+            "change_detail.html",
+            {
+                "request": request,
+                "change": change,
+                "source_name": source_name,
+                "category_name": category_name,
+                "error_message": str(e),
+            },
+            status_code=400,
+        )
+
+
+

--- a/src/offsight/ui/templates/base.html
+++ b/src/offsight/ui/templates/base.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}OffSight™ - Regulatory Intelligence{% endblock %}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+    <style>
+        .status-badge {
+            display: inline-block;
+            padding: 0.25rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+            font-weight: 500;
+        }
+        .status-pending { background-color: #fef3c7; color: #92400e; }
+        .status-ai_suggested { background-color: #dbeafe; color: #1e40af; }
+        .status-validated { background-color: #d1fae5; color: #065f46; }
+        .status-corrected { background-color: #e0e7ff; color: #3730a3; }
+        .status-rejected { background-color: #fee2e2; color: #991b1b; }
+        .message-success { background-color: #d1fae5; color: #065f46; padding: 1rem; border-radius: 0.5rem; margin: 1rem 0; }
+        .message-error { background-color: #fee2e2; color: #991b1b; padding: 1rem; border-radius: 0.5rem; margin: 1rem 0; }
+        pre { overflow-x: auto; background-color: #f3f4f6; padding: 1rem; border-radius: 0.5rem; }
+        .summary-preview { max-width: 400px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    </style>
+</head>
+<body>
+    <nav class="container-fluid">
+        <ul>
+            <li><strong>OffSight™</strong></li>
+        </ul>
+        <ul>
+            <li><a href="/ui/changes">Changes</a></li>
+            <li><a href="/health">Health</a></li>
+            <li><a href="/docs">Docs</a></li>
+        </ul>
+    </nav>
+    <main class="container">
+        {% block content %}{% endblock %}
+    </main>
+</body>
+</html>
+

--- a/src/offsight/ui/templates/change_detail.html
+++ b/src/offsight/ui/templates/change_detail.html
@@ -1,0 +1,118 @@
+{% extends "base.html" %}
+
+{% block title %}Change #{{ change.id }} - OffSight™{% endblock %}
+
+{% block content %}
+<h1>Change #{{ change.id }}</h1>
+
+{% if error_message %}
+<div class="message-error">{{ error_message }}</div>
+{% endif %}
+
+{% if success_message %}
+<div class="message-success">{{ success_message }}</div>
+{% endif %}
+
+<!-- Metadata Section -->
+<article>
+    <h2>Metadata</h2>
+    <div class="grid">
+        <div>
+            <strong>Source:</strong> {{ source_name }}<br>
+            <strong>Detected At:</strong> {{ change.detected_at.strftime('%Y-%m-%d %H:%M:%S') }}<br>
+            <strong>Status:</strong> 
+            <span class="status-badge status-{{ change.status }}">
+                {{ change.status.replace('_', ' ').title() }}
+            </span>
+        </div>
+        <div>
+            <strong>Previous Version:</strong> {{ previous_version or '-' }}<br>
+            <strong>New Version:</strong> {{ new_version or '-' }}
+        </div>
+    </div>
+</article>
+
+<!-- AI Suggestion Section -->
+{% if change.ai_summary or category_name %}
+<article>
+    <h2>AI Suggestion</h2>
+    <p><strong>Category:</strong> {{ category_name or '-' }}</p>
+    <p><strong>Summary:</strong></p>
+    <p>{{ change.ai_summary or 'No AI summary available.' }}</p>
+</article>
+{% endif %}
+
+<!-- Diff Content Section -->
+<article>
+    <h2>Change Diff</h2>
+    <pre>{{ change.diff_content }}</pre>
+</article>
+
+<!-- Validation Form -->
+{% if change.status in ['pending', 'ai_suggested'] %}
+<article>
+    <h2>Validate Change</h2>
+    <form method="post" action="/ui/changes/{{ change.id }}/validate">
+        <label for="decision">Decision *</label>
+        <select name="decision" id="decision" required>
+            <option value="">Select decision...</option>
+            <option value="approved">Approve (accept AI suggestion)</option>
+            <option value="corrected">Correct (edit AI suggestion)</option>
+            <option value="rejected">Reject (AI suggestion is wrong)</option>
+        </select>
+
+        <label for="final_summary">Final Summary</label>
+        <textarea name="final_summary" id="final_summary" rows="4" placeholder="Required if correcting or rejecting">{{ change.ai_summary or '' }}</textarea>
+        <small>Required when decision is "corrected" or "rejected"</small>
+
+        <label for="final_category">Final Category</label>
+        <input type="text" name="final_category" id="final_category" list="categories" placeholder="e.g., Safety and Health" value="{{ category_name or '' }}">
+        <datalist id="categories">
+            <option value="Grid Connection">
+            <option value="Safety and Health">
+            <option value="Environment">
+            <option value="Certification/Documentation">
+            <option value="Other">
+        </datalist>
+        <small>Required when decision is "corrected"</small>
+
+        <label for="notes">Notes</label>
+        <textarea name="notes" id="notes" rows="3" placeholder="Optional notes about your validation decision"></textarea>
+
+        <button type="submit">Submit Validation</button>
+    </form>
+</article>
+{% endif %}
+
+<!-- Validation History Section -->
+{% if validations %}
+<article>
+    <h2>Validation History</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>Decision</th>
+                <th>Validated At</th>
+                <th>Notes</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for validation in validations %}
+            <tr>
+                <td>
+                    <span class="status-badge status-{{ validation.decision }}">
+                        {{ validation.decision.replace('_', ' ').title() }}
+                    </span>
+                </td>
+                <td>{{ validation.validated_at.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+                <td>{{ validation.notes or '-' }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</article>
+{% endif %}
+
+<p><a href="/ui/changes">← Back to Changes List</a></p>
+{% endblock %}
+

--- a/src/offsight/ui/templates/changes_list.html
+++ b/src/offsight/ui/templates/changes_list.html
@@ -1,0 +1,70 @@
+{% extends "base.html" %}
+
+{% block title %}Detected Regulatory Changes - OffSight™{% endblock %}
+
+{% block content %}
+<h1>Detected Regulatory Changes</h1>
+
+<!-- Filter Form -->
+<form method="get" action="/ui/changes">
+    <div class="grid">
+        <div>
+            <label for="status">Status</label>
+            <select name="status" id="status">
+                <option value="">All</option>
+                <option value="pending" {% if status == "pending" %}selected{% endif %}>Pending</option>
+                <option value="ai_suggested" {% if status == "ai_suggested" %}selected{% endif %}>AI Suggested</option>
+                <option value="validated" {% if status == "validated" %}selected{% endif %}>Validated</option>
+                <option value="corrected" {% if status == "corrected" %}selected{% endif %}>Corrected</option>
+                <option value="rejected" {% if status == "rejected" %}selected{% endif %}>Rejected</option>
+            </select>
+        </div>
+        <div>
+            <label for="source_id">Source ID</label>
+            <input type="number" name="source_id" id="source_id" value="{{ source_id or '' }}" placeholder="Filter by source">
+        </div>
+        <div>
+            <label>&nbsp;</label>
+            <button type="submit">Filter</button>
+        </div>
+    </div>
+</form>
+
+{% if changes %}
+<table>
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Detected At</th>
+            <th>Source</th>
+            <th>Status</th>
+            <th>Category</th>
+            <th>Summary</th>
+            <th>Action</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for change in changes %}
+        <tr>
+            <td>{{ change.id }}</td>
+            <td>{{ change.detected_at.strftime('%Y-%m-%d %H:%M') }}</td>
+            <td>{{ change.source_name }}</td>
+            <td>
+                <span class="status-badge status-{{ change.status }}">
+                    {{ change.status.replace('_', ' ').title() }}
+                </span>
+            </td>
+            <td>{{ change.category_name or '-' }}</td>
+            <td class="summary-preview">{{ change.ai_summary[:120] if change.ai_summary else '-' }}{% if change.ai_summary and change.ai_summary|length > 120 %}...{% endif %}</td>
+            <td><a href="/ui/changes/{{ change.id }}" role="button" class="secondary">View</a></td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<article>
+    <p>No changes found. {% if status or source_id %}Try adjusting your filters.{% else %}Run the scraper and change detection to see changes here.{% endif %}</p>
+</article>
+{% endif %}
+{% endblock %}
+


### PR DESCRIPTION
### What changed
- Added server-rendered UI under /ui (PicoCSS + Jinja2):
  - GET /ui/changes (filters + overview table)
  - GET /ui/changes/{id} (detail view with diff + AI suggestion)
  - POST /ui/changes/{id}/validate (approve/correct/reject)
- Extracted shared validation logic into ValidationService to avoid duplication
- Added Jinja2 and python-multipart dependencies
- Wired UI router into FastAPI app

### How to demo
1) $env:PYTHONPATH="src"; uvicorn src.offsight.main:app --reload
2) Open http://localhost:8000/ui/changes
3) View a change and submit validation

Closes #14 